### PR TITLE
Adjust to current incident numbers

### DIFF
--- a/exercises/ex4/README.md
+++ b/exercises/ex4/README.md
@@ -14,9 +14,9 @@ After completing these steps, you will have added two formatters to the controll
 		}
 
 		formatIconColor(incidence: number) {
-			if (incidence < 500) {
+			if (incidence < 50) {
 				return IconColor.Default;
-			} else if (incidence < 800) {
+			} else if (incidence < 100) {
 				return IconColor.Critical;
 			} else {
 				return IconColor.Negative;


### PR DESCRIPTION
The example won't work with the current incident numbers. 500 for warning and 800 for critical results currently that all numbers are formatted as default. Looking at the current numbers, values like 50 for default, 100 for warning and everything above gives a better result when running the example.