### PR TITLE
added correct line for routing

### DIFF
--- a/exercises/ex6/README.md
+++ b/exercises/ex6/README.md
@@ -17,7 +17,7 @@ After completing these steps, incidence history data of the past 100 days is ava
 			const model = new JSONModel("https://api.corona-zahlen.org/states/history/incidence/100");
 			this.setModel(model, "incidenceHistory");
 
-			UIComponent.getRouterFor(this).getRoute("IncidenceDetailRoute").attachMatched(this.onRouteMatched.bind(this));
+			this.getRouter().getRoute("IncidenceDetailRoute").attachMatched(this.onRouteMatched.bind(this));
 		}
 
 		onRouteMatched(event: Event) {


### PR DESCRIPTION
The onInit method contains the wrong reference for routing. It is using UIComponent instead of this.getRouter. This results currently in a TS error, as UIComponent is not known. Looking at the example source code ex6/com.myorg.myapp/src/controller/IncidenceDetail.controller.ts the correct code is used: this.getRouter().getRoute...

I added the line so the example and the source code match.